### PR TITLE
Mm version1 18

### DIFF
--- a/phenix/bibtex.py
+++ b/phenix/bibtex.py
@@ -61,7 +61,9 @@ _bibtexStr = """
    Volume="74",
    Number="Pt 9",
    Pages="814--840",
-   Month="Sep"
+   Month="Sep",
+   doi = "https://doi.org/10.1107/S2059798318009324",
+   url = "http://scripts.iucr.org/cgi-bin/paper?S2059798318009324"
 }
 
 @Article{Chen_2010,

--- a/phenix/constants.py
+++ b/phenix/constants.py
@@ -27,6 +27,7 @@
 PHENIX_HOME = 'PHENIX_HOME'
 PHENIXVERSIONFILENAME = './phenix_env.sh'
 PHENIXVERSION = '1.13' # plugin version
+PHENIXVERSION18 = '1.18' # september 2020
 
 #python used to run phenix scripts
 PHENIX_PYTHON = 'phenix.python '  # keep the ending space

--- a/phenix/tests/test_phenix_pdb_cif.py
+++ b/phenix/tests/test_phenix_pdb_cif.py
@@ -33,7 +33,7 @@ from phenix.protocols.protocol_real_space_refine import (PhenixProtRunRSRefine,
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from phenix.protocols.protocol_validation_cryoem import PhenixProtRunValidationCryoEM
 from pyworkflow.tests import *
-from phenix import Plugin, PHENIXVERSION
+from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18
 import json
 from phenix.protocols.protocol_emringer import PhenixProtRunEMRinger
 from phenix.protocols.protocol_superpose_pdbs import PhenixProtRunSuperposePDBs
@@ -379,7 +379,14 @@ class TestPhenixPdbCif(TestImportData):
                                       clashScore=2.43,
                                       overallScore=1.12,
                                       protRSRefine=protRSRefine)
-
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.64,
+                                      rotOutliers=4.77,
+                                      cbetaOutliers=0,
+                                      clashScore=6.07,
+                                      overallScore=2.06,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -409,6 +416,14 @@ class TestPhenixPdbCif(TestImportData):
                                 cbetaOutliers=0,
                                 clashScore=2.43,
                                 overallScore=1.12,
+                                protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkMPResults(ramOutliers=0.00,
+                                ramFavored=96.64,
+                                rotOutliers=4.77,
+                                cbetaOutliers=0,
+                                clashScore=6.07,
+                                overallScore=2.06,
                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,
@@ -529,7 +544,14 @@ class TestPhenixPdbCif(TestImportData):
                                       clashScore=2.43,
                                       overallScore=1.12,
                                       protRSRefine=protRSRefine)
-
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.64,
+                                      rotOutliers=4.77,
+                                      cbetaOutliers=0,
+                                      clashScore=6.07,
+                                      overallScore=2.06,
+                                      protRSRefine=protRSRefine)
         else:
             # values obtained from phenix GUI v. 1.16
             # (minimization_global + adp)
@@ -561,6 +583,14 @@ class TestPhenixPdbCif(TestImportData):
                                 cbetaOutliers=0,
                                 clashScore=2.43,
                                 overallScore=1.12,
+                                protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkMPResults(ramOutliers=0.00,
+                                ramFavored=96.64,
+                                rotOutliers=4.77,
+                                cbetaOutliers=0,
+                                clashScore=6.07,
+                                overallScore=2.06,
                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,
@@ -683,6 +713,15 @@ class TestPhenixPdbCif(TestImportData):
                                       overallScore=1.12,
                                       protRSRefine=protRSRefine)
 
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.64,
+                                      rotOutliers=4.77,
+                                      cbetaOutliers=0,
+                                      clashScore=6.07,
+                                      overallScore=2.06,
+                                      protRSRefine=protRSRefine)
+
         else:
             # values obtained from phenix GUI v. 1.16
             # (minimization_global + adp)
@@ -714,6 +753,14 @@ class TestPhenixPdbCif(TestImportData):
                                 cbetaOutliers=0,
                                 clashScore=2.43,
                                 overallScore=1.12,
+                                protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkMPResults(ramOutliers=0.00,
+                                ramFavored=96.64,
+                                rotOutliers=4.77,
+                                cbetaOutliers=0,
+                                clashScore=6.07,
+                                overallScore=2.06,
                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,

--- a/phenix/tests/test_protocol_molprobity.py
+++ b/phenix/tests/test_protocol_molprobity.py
@@ -28,6 +28,7 @@ from pwem.protocols.protocol_import import (ProtImportPdb,
                                                     ProtImportVolumes)
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from pyworkflow.tests import *
+from phenix import PHENIXVERSION18, Plugin
 
 
 class TestImportBase(BaseTest):
@@ -624,13 +625,22 @@ class TestMolprobityValidation2(TestImportData):
         self.launchProtocol(protMolProbity)
 
         # check MolProbity results
-        self.checkResults(ramOutliers=0.12,
-                          ramFavored=95.86,
-                          rotOutliers=0.52,
-                          cbetaOutliers=0,
-                          clashScore=9.74,
-                          overallScore=1.80,
-                          protMolProbity=protMolProbity)
+        if Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkResults(ramOutliers=0.12,
+                              ramFavored=95.86,
+                              rotOutliers=0.52,
+                              cbetaOutliers=0,
+                              clashScore=9.70,
+                              overallScore=1.80,
+                              protMolProbity=protMolProbity)
+        else:
+            self.checkResults(ramOutliers=0.12,
+                              ramFavored=95.86,
+                              rotOutliers=0.52,
+                              cbetaOutliers=0,
+                              clashScore=9.74,
+                              overallScore=1.80,
+                              protMolProbity=protMolProbity)
 
     def testMolProbityValidationManyOutliers1(self):
         """ This test checks that MolProbity validation protocol runs with

--- a/phenix/tests/test_protocol_real_space_refine.py
+++ b/phenix/tests/test_protocol_real_space_refine.py
@@ -30,7 +30,7 @@ from phenix.protocols.protocol_real_space_refine import (PhenixProtRunRSRefine,
                                                          mmCIF)
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from pyworkflow.tests import *
-from phenix import Plugin, PHENIXVERSION
+from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18
 
 
 class TestImportBase(BaseTest):
@@ -370,6 +370,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=2.43,
                                       overallScore=1.12,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.64,
+                                      rotOutliers=4.77,
+                                      cbetaOutliers=0,
+                                      clashScore=6.07,
+                                      overallScore=2.06,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -453,6 +461,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=2.43,
                                       overallScore=1.12,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.64,
+                                      rotOutliers=4.77,
+                                      cbetaOutliers=0,
+                                      clashScore=6.07,
+                                      overallScore=2.06,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -532,6 +548,14 @@ class TestPhenixRSRefine(TestImportData):
                                       cbetaOutliers=0,
                                       clashScore=2.10,
                                       overallScore=1.11,
+                                      protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=97.89,
+                                      rotOutliers=0.00,
+                                      cbetaOutliers=0,
+                                      clashScore=3.76,
+                                      overallScore=1.19,
                                       protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
@@ -620,7 +644,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=2.10,
                                       overallScore=1.11,
                                       protRSRefine=protRSRefine)
-
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=97.52,
+                                      rotOutliers=0.00,
+                                      cbetaOutliers=0,
+                                      clashScore=3.64,
+                                      overallScore=1.25,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.29,
@@ -711,7 +742,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=2.43,
                                       overallScore=1.12,
                                       protRSRefine=protRSRefine)
-
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.64,
+                                      rotOutliers=4.77,
+                                      cbetaOutliers=0,
+                                      clashScore=6.07,
+                                      overallScore=2.06,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -805,6 +843,14 @@ class TestPhenixRSRefine(TestImportData):
                                       cbetaOutliers=0,
                                       clashScore=2.10,
                                       overallScore=1.11,
+                                      protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=97.52,
+                                      rotOutliers=0.00,
+                                      cbetaOutliers=0,
+                                      clashScore=3.64,
+                                      overallScore=1.25,
                                       protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,

--- a/phenix/tests/test_protocol_validation_cryoem.py
+++ b/phenix/tests/test_protocol_validation_cryoem.py
@@ -33,7 +33,7 @@ from phenix.protocols.protocol_real_space_refine import (PhenixProtRunRSRefine,
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from phenix.protocols.protocol_validation_cryoem import PhenixProtRunValidationCryoEM
 from pyworkflow.tests import *
-from phenix import Plugin, PHENIXVERSION
+from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18
 
 
 class TestImportBase(BaseTest):
@@ -488,6 +488,14 @@ class TestValCryoEM(TestImportData):
                                 clashScore=2.43,
                                 overallScore=1.12,
                                 protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkMPResults(ramOutliers=0.00,
+                                ramFavored=96.64,
+                                rotOutliers=4.77,
+                                cbetaOutliers=0,
+                                clashScore=6.07,
+                                overallScore=2.06,
+                                protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,
                                 ramFavored=96.11,
@@ -521,14 +529,22 @@ class TestValCryoEM(TestImportData):
 
             return
         # self.assertTrue(False)
-
-        self.checkValCryoEMResults(ramOutliers=0.00,
-                                  ramFavored=95.41,
-                                  rotOutliers=3.47,
-                                  cbetaOutliers=0,
-                                  clashScore=4.75,
-                                  overallScore=1.98,
-                                  protValCryoEM=protValCryoEM)
+        if Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkValCryoEMResults(ramOutliers=0.00,
+                                       ramFavored=96.64,
+                                       rotOutliers=4.77,
+                                       cbetaOutliers=0,
+                                       clashScore=6.07,
+                                       overallScore=2.06,
+                                       protValCryoEM=protValCryoEM)
+        else:
+            self.checkValCryoEMResults(ramOutliers=0.00,
+                                      ramFavored=95.41,
+                                      rotOutliers=3.47,
+                                      cbetaOutliers=0,
+                                      clashScore=4.75,
+                                      overallScore=1.98,
+                                      protValCryoEM=protValCryoEM)
 
     def testValCryoEMFFromVolumeAssociatedToPDB3(self):
         """ This test checks that phenix real_space_refine protocol runs
@@ -587,7 +603,14 @@ class TestValCryoEM(TestImportData):
                                       clashScore=7.46,
                                       overallScore=1.69,
                                       protRSRefine=protRSRefine)
-
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=96.19,
+                                      rotOutliers=12.32,
+                                      cbetaOutliers=0,
+                                      clashScore=12.40,
+                                      overallScore=2.69,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=94.42,
@@ -615,6 +638,14 @@ class TestValCryoEM(TestImportData):
                                 cbetaOutliers=0,
                                 clashScore=7.46,
                                 overallScore=1.69,
+                                protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkMPResults(ramOutliers=0.00,
+                                ramFavored=96.19,
+                                rotOutliers=12.32,
+                                cbetaOutliers=0,
+                                clashScore=12.45,
+                                overallScore=2.69,
                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,
@@ -652,13 +683,22 @@ class TestValCryoEM(TestImportData):
         # self.assertTrue(False)
 
         # check validation cryoem results
-        self.checkValCryoEMResults(ramOutliers=0.00,
-                                  ramFavored=94.42,
-                                  rotOutliers=11.04,
-                                  cbetaOutliers=0,
-                                  clashScore=12.96,
-                                  overallScore=2.80,
-                                  protValCryoEM=protValCryoEM)
+        if Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkValCryoEMResults(ramOutliers=0.00,
+                                       ramFavored=96.19,
+                                       rotOutliers=12.32,
+                                       cbetaOutliers=0,
+                                       clashScore=12.40,
+                                       overallScore=2.69,
+                                       protValCryoEM=protValCryoEM)
+        else:
+            self.checkValCryoEMResults(ramOutliers=0.00,
+                                      ramFavored=94.42,
+                                      rotOutliers=11.04,
+                                      cbetaOutliers=0,
+                                      clashScore=12.96,
+                                      overallScore=2.80,
+                                      protValCryoEM=protValCryoEM)
 
     def testValCryoEMFFromVolumeAndPDB4(self):
         """ This test checks that phenix real_space_refine protocol runs
@@ -753,6 +793,14 @@ class TestValCryoEM(TestImportData):
                                 cbetaOutliers=0,
                                 clashScore=2.43,
                                 overallScore=1.12,
+                                protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION18:
+            self.checkMPResults(ramOutliers=0.00,
+                                ramFavored=96.64,
+                                rotOutliers=4.77,
+                                cbetaOutliers=0,
+                                clashScore=6.07,
+                                overallScore=2.06,
                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,


### PR DESCRIPTION
Hi all,

here you are some small changes to adapt the tests ALSO to the results of the new phenix version 1.18.2-3874:

scipion3 tests phenix.tests.test_phenix_pdb_cif;
scipion3 tests phenix.tests.test_protocol_molprobity;
scipion3 tests phenix.tests.test_protocol_real_space_refine;
scipion3 tests phenix.tests.test_protocol_validation_cryoem