### PR TITLE
Updated plugin for Phenix version 1.20

### DIFF
--- a/phenix/constants.py
+++ b/phenix/constants.py
@@ -29,6 +29,7 @@ PHENIXVERSIONFILENAME = './phenix_env.sh'
 PHENIXVERSION = '1.13' # plugin version
 PHENIXVERSION18 = '1.18' # september 2020
 PHENIXVERSION19 = '1.19' # june 2021
+PHENIXVERSION20 = '1.20' # march 2022
 
 #python used to run phenix scripts
 PHENIX_PYTHON = 'phenix.python '  # keep the ending space

--- a/phenix/tests/test_phenix_pdb_cif.py
+++ b/phenix/tests/test_phenix_pdb_cif.py
@@ -33,7 +33,7 @@ from phenix.protocols.protocol_real_space_refine import (PhenixProtRunRSRefine,
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from phenix.protocols.protocol_validation_cryoem import PhenixProtRunValidationCryoEM
 from pyworkflow.tests import *
-from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18, PHENIXVERSION19
+from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18, PHENIXVERSION19, PHENIXVERSION20
 import json
 from phenix.protocols.protocol_emringer import PhenixProtRunEMRinger
 from phenix.protocols.protocol_superpose_pdbs import PhenixProtRunSuperposePDBs
@@ -396,6 +396,14 @@ class TestPhenixPdbCif(TestImportData):
                                       clashScore=3.87,
                                       overallScore=1.59,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -442,6 +450,14 @@ class TestPhenixPdbCif(TestImportData):
                                 clashScore=3.87,
                                 overallScore=1.59,
                                 protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkMPResults(ramOutliers=0.00,
                                 ramFavored=96.11,
@@ -585,6 +601,14 @@ class TestPhenixPdbCif(TestImportData):
                                       clashScore=3.87,
                                       overallScore=1.59,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             # values obtained from phenix GUI v. 1.16
             # (minimization_global + adp)
@@ -633,6 +657,14 @@ class TestPhenixPdbCif(TestImportData):
                                 clashScore=3.87,
                                 overallScore=1.59,
                                 protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkMPResults(ramOutliers=0.00,
                                 ramFavored=96.11,
@@ -780,6 +812,14 @@ class TestPhenixPdbCif(TestImportData):
                                       clashScore=3.87,
                                       overallScore=1.59,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             # values obtained from phenix GUI v. 1.16
             # (minimization_global + adp)
@@ -828,6 +868,14 @@ class TestPhenixPdbCif(TestImportData):
                                 clashScore=3.87,
                                 overallScore=1.59,
                                 protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkMPResults(ramOutliers=0.00,
                                 ramFavored=96.11,

--- a/phenix/tests/test_protocol_molprobity.py
+++ b/phenix/tests/test_protocol_molprobity.py
@@ -28,7 +28,7 @@ from pwem.protocols.protocol_import import (ProtImportPdb,
                                                     ProtImportVolumes)
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from pyworkflow.tests import *
-from phenix import PHENIXVERSION18, Plugin
+from phenix import PHENIXVERSION18, PHENIXVERSION20, Plugin
 
 
 class TestImportBase(BaseTest):
@@ -664,13 +664,22 @@ class TestMolprobityValidation2(TestImportData):
         self.launchProtocol(protMolProbity)
 
         # check MolProbity results
-        self.checkResults(ramOutliers=0.20,
-                          ramFavored=97.35,
-                          rotOutliers=12.24,
-                          cbetaOutliers=0,
-                          clashScore=130.72,
-                          overallScore=3.53,
-                          protMolProbity=protMolProbity)
+        if Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkResults(ramOutliers=0.20,
+                              ramFavored=97.35,
+                              rotOutliers=12.24,
+                              cbetaOutliers=0,
+                              clashScore=132.67,
+                              overallScore=3.54,
+                              protMolProbity=protMolProbity)
+        else:
+            self.checkResults(ramOutliers=0.20,
+                              ramFavored=97.35,
+                              rotOutliers=12.24,
+                              cbetaOutliers=0,
+                              clashScore=130.72,
+                              overallScore=3.53,
+                              protMolProbity=protMolProbity)
 
     def testMolProbityValidationManyOutliers2(self):
         """ This test checks that MolProbity validation protocol runs with
@@ -693,11 +702,20 @@ class TestMolprobityValidation2(TestImportData):
         self.launchProtocol(protMolProbity)
 
         # check MolProbity results
-        self.checkResults(ramOutliers=3.82,
-                          ramFavored=89.09,
-                          rotOutliers=31.35,
-                          cbetaOutliers=746,
-                          clashScore=276.52,
-                          overallScore=4.61,
-                          protMolProbity=protMolProbity)
+        if Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkResults(ramOutliers=3.82,
+                              ramFavored=89.09,
+                              rotOutliers=31.44,
+                              cbetaOutliers=746,
+                              clashScore=281.68,
+                              overallScore=4.62,
+                              protMolProbity=protMolProbity)
+        else:
+            self.checkResults(ramOutliers=3.82,
+                              ramFavored=89.09,
+                              rotOutliers=31.35,
+                              cbetaOutliers=746,
+                              clashScore=276.52,
+                              overallScore=4.61,
+                              protMolProbity=protMolProbity)
 

--- a/phenix/tests/test_protocol_real_space_refine.py
+++ b/phenix/tests/test_protocol_real_space_refine.py
@@ -30,7 +30,7 @@ from phenix.protocols.protocol_real_space_refine import (PhenixProtRunRSRefine,
                                                          mmCIF)
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from pyworkflow.tests import *
-from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18, PHENIXVERSION19
+from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18, PHENIXVERSION19, PHENIXVERSION20
 
 
 class TestImportBase(BaseTest):
@@ -309,6 +309,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=2.09,
                                       overallScore=1.16,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.4717,
+                                      ramFavored=83.96,
+                                      rotOutliers=5.68,
+                                      cbetaOutliers=1,
+                                      clashScore=4.77,
+                                      overallScore=2.50,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.70,
@@ -393,6 +401,14 @@ class TestPhenixRSRefine(TestImportData):
                                       cbetaOutliers=0,
                                       clashScore=3.87,
                                       overallScore=1.59,
+                                      protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
                                       protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
@@ -494,6 +510,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=3.87,
                                       overallScore=1.59,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -581,6 +605,14 @@ class TestPhenixRSRefine(TestImportData):
                                       cbetaOutliers=0,
                                       clashScore=3.76,
                                       overallScore=1.19,
+                                      protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
                                       protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
@@ -677,6 +709,14 @@ class TestPhenixRSRefine(TestImportData):
                                       cbetaOutliers=0,
                                       clashScore=3.64,
                                       overallScore=1.25,
+                                      protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
                                       protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
@@ -785,6 +825,14 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=3.87,
                                       overallScore=1.59,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.11,
@@ -887,6 +935,14 @@ class TestPhenixRSRefine(TestImportData):
                                       cbetaOutliers=0,
                                       clashScore=3.64,
                                       overallScore=1.25,
+                                      protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.00,
+                                      ramFavored=95.23,
+                                      rotOutliers=0.43,
+                                      cbetaOutliers=0,
+                                      clashScore=3.53,
+                                      overallScore=1.48,
                                       protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,

--- a/phenix/tests/test_protocol_validation_cryoem.py
+++ b/phenix/tests/test_protocol_validation_cryoem.py
@@ -33,7 +33,7 @@ from phenix.protocols.protocol_real_space_refine import (PhenixProtRunRSRefine,
 from phenix.protocols.protocol_molprobity import PhenixProtRunMolprobity
 from phenix.protocols.protocol_validation_cryoem import PhenixProtRunValidationCryoEM
 from pyworkflow.tests import *
-from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18, PHENIXVERSION19
+from phenix import Plugin, PHENIXVERSION, PHENIXVERSION18, PHENIXVERSION19, PHENIXVERSION20
 
 
 class TestImportBase(BaseTest):
@@ -324,6 +324,14 @@ class TestValCryoEM(TestImportData):
                                       clashScore=2.09,
                                       overallScore=1.27,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=0.47,
+                                      ramFavored=83.96,
+                                      rotOutliers=5.68,
+                                      cbetaOutliers=1,
+                                      clashScore=4.77,
+                                      overallScore=2.50,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=96.23,
@@ -361,6 +369,14 @@ class TestValCryoEM(TestImportData):
                                 clashScore=2.09,
                                 overallScore=1.16,
                                 protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkMPResults(ramOutliers=0.47,
+                                 ramFavored=83.96,
+                                 rotOutliers=5.68,
+                                 cbetaOutliers=1,
+                                 clashScore=4.77,
+                                 overallScore=2.50,
+                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,
                                 ramFavored=96.23,
@@ -396,7 +412,16 @@ class TestValCryoEM(TestImportData):
         # self.assertTrue(False)
 
         # check validation cryoem results
-        self.checkValCryoEMResults(ramOutliers=0.00,
+        if Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkValCryoEMResults(ramOutliers=0.47,
+                                       ramFavored=83.96,
+                                       rotOutliers=5.68,
+                                       cbetaOutliers=1,
+                                       clashScore=4.77,
+                                       overallScore=2.50,
+                                       protValCryoEM=protValCryoEM)
+        else:
+            self.checkValCryoEMResults(ramOutliers=0.00,
                                   ramFavored=96.70,
                                   rotOutliers=3.98,
                                   cbetaOutliers=0,
@@ -642,6 +667,14 @@ class TestValCryoEM(TestImportData):
                                       clashScore=7.65,
                                       overallScore=1.75,
                                       protRSRefine=protRSRefine)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkRSRefineResults(ramOutliers=1.77,
+                                      ramFavored=87.62,
+                                      rotOutliers=10.40,
+                                      cbetaOutliers=2,
+                                      clashScore=12.73,
+                                      overallScore=3.00,
+                                      protRSRefine=protRSRefine)
         else:
             self.checkRSRefineResults(ramOutliers=0.00,
                                       ramFavored=94.42,
@@ -685,6 +718,14 @@ class TestValCryoEM(TestImportData):
                                 cbetaOutliers=0,
                                 clashScore=7.65,
                                 overallScore=1.75,
+                                protMolProbity=protMolProbity2)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkMPResults(ramOutliers=1.77,
+                                ramFavored=87.62,
+                                rotOutliers=10.40,
+                                cbetaOutliers=2,
+                                clashScore=11.11,
+                                overallScore=2.94,
                                 protMolProbity=protMolProbity2)
         else:
             self.checkMPResults(ramOutliers=0.00,
@@ -737,6 +778,14 @@ class TestValCryoEM(TestImportData):
                                        cbetaOutliers=0,
                                        clashScore=7.65,
                                        overallScore=1.75,
+                                       protValCryoEM=protValCryoEM)
+        elif Plugin.getPhenixVersion() == PHENIXVERSION20:
+            self.checkValCryoEMResults(ramOutliers=1.77,
+                                       ramFavored=87.62,
+                                       rotOutliers=10.40,
+                                       cbetaOutliers=2,
+                                       clashScore=11.11,
+                                       overallScore=2.94,
                                        protValCryoEM=protValCryoEM)
         else:
             self.checkValCryoEMResults(ramOutliers=0.00,


### PR DESCRIPTION
Several tests of the scipion-em-phenix plugin have been updated fo include calcuted values by PHENIX v. 1.20:

Modified files:
        phenix/constants.py
	phenix/tests/test_phenix_pdb_cif.py
	phenix/tests/test_protocol_molprobity.py
	phenix/tests/test_protocol_real_space_refine.py
	phenix/tests/test_protocol_validation_cryoem.py


Tests: 
scipion3 tests phenix.tests.test_protocol_validation_cryoem.TestValCryoEM;
scipion3 tests phenix.tests.test_protocol_real_space_refine.TestPhenixRSRefine;
scipion3 tests phenix.tests.test_protocol_molprobity.TestMolprobityValidation2;
scipion3 tests phenix.tests.test_phenix_pdb_cif.TestPhenixPdbCif;

scipion3 test --run | grep phenix also works fine!