### PR TITLE
JMK add rigid body file to real space refinement

### DIFF
--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -349,8 +349,8 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
             for rigidBody in self.rigidBodySelections.get().split('\n'):
                 rigidBody = rigidBody.strip()
                 if not rigidBody.startswith('group'):
-                    rigidBody = "group = {0}\n".format(rigidBody)
-                fi.write(rigidBody)
+                    rigidBody = "group = {0}".format(rigidBody)
+                fi.write(rigidBody + "\n")
 
             fi.write("}\n")
             fi.close()

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -343,14 +343,16 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
 
         if self.rigidBodySelections.get() != "":
             RIGID_BODY_FILENAME = self._getExtraPath("rigid.eff")
-            fi = open(RIGID_BODY_FILENAME, 'r')
-
+            fi = open(RIGID_BODY_FILENAME, 'w')
             fi.write("refinement.rigid_body {\n")
 
             for rigidBody in self.rigidBodySelections.get().split('\n'):
-                fi.write("group = {0}\n".format(rigidBody))
+                if not rigidBody.startswith('group'):
+                    rigidBody = "group = {0}\n".format(rigidBody)
+                fi.write(rigidBody)
 
             fi.write("}\n")
+            fi.close()
 
             args += " " + RIGID_BODY_FILENAME
             

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -101,7 +101,11 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
         group.addParam('rigidBodySelections', TextParam, width=30,
                        condition='rigidBody==True',
                        label='Rigid body selections',
-                       help='Write a new rigid body selection definition on each line')
+                       help='Write a new rigid body selection definition on each line. '
+                            'Rigid body selections can include chain and residue sequence IDs '
+                            'with any number of blocks separated by AND and OR e.g. '
+                            'group = """chain A AND resseq 25:319 OR chain A AND resid 1301 OR chain A AND resseq 1304:1307""". '
+                            'See https://phenix-online.org/documentation/reference/atom_selections.html#examples-for-selection-expressions')
         group.addParam('localGridSearch', BooleanParam,
                        label="Local grid search: ", default=True,
                        expertLevel=LEVEL_ADVANCED,

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -28,7 +28,7 @@
 import os
 
 from pwem.objects import AtomStruct
-from pyworkflow.protocol.params import BooleanParam,  IntParam
+from pyworkflow.protocol.params import BooleanParam, IntParam, TextParam
 from phenix.constants import (REALSPACEREFINE,
                               MOLPROBITY2,
                               VALIDATION_CRYOEM,
@@ -98,6 +98,10 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
                        help="Refinement strategy that considers groups of "
                             "atoms that move (rotate and translate) as a "
                             "single body.\n")
+        group.addParam('rigidBodySelections', TextParam, width=30,
+                       condition='rigidBody==True',
+                       label='Rigid body selections',
+                       help='Write a new rigid body selection definition on each line')
         group.addParam('localGridSearch', BooleanParam,
                        label="Local grid search: ", default=True,
                        expertLevel=LEVEL_ADVANCED,
@@ -336,6 +340,20 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
         if self.nqh_flips == True:
             args += "nqh_flips+"
         args = args[:-1]
+
+        if self.rigidBodySelections.get() != "":
+            RIGID_BODY_FILENAME = self._getExtraPath("rigid.eff")
+            fi = open(RIGID_BODY_FILENAME, 'r')
+
+            fi.write("refinement.rigid_body {\n")
+
+            for rigidBody in self.rigidBodySelections.get().split('\n'):
+                fi.write("group = {0}\n".format(rigidBody))
+
+            fi.write("}\n")
+
+            args += " " + RIGID_BODY_FILENAME
+            
         # args += " run=minimization_global+local_grid_search+morphing+simulated_annealing"
         if self.macroCycles != 5:
             args += " macro_cycles=%d" % self.macroCycles

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -345,7 +345,7 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
             args += "nqh_flips+"
         args = args[:-1]
 
-        if self.rigidBodySelections.get() != "":
+        if self.rigidBodySelections.hasValue():
             RIGID_BODY_FILENAME = os.path.abspath(self._getExtraPath("rigid.eff"))
             fi = open(RIGID_BODY_FILENAME, 'w')
             fi.write("refinement.rigid_body {\n")

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -100,6 +100,7 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
                             "single body.\n")
         group.addParam('rigidBodySelections', TextParam, width=30,
                        condition='rigidBody==True',
+                       expertLevel=LEVEL_ADVANCED,
                        label='Rigid body selections',
                        help='Write a new rigid body selection definition on each line. '
                             'Rigid body selections can include chain and residue sequence IDs '

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -350,7 +350,7 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
                 rigidBody = rigidBody.strip()
                 if not rigidBody.startswith('group'):
                     rigidBody = "group = {0}".format(rigidBody)
-                fi.write(rigidBody + "\n")
+                fi.write("\t" + rigidBody + "\n")
 
             fi.write("}\n")
             fi.close()

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -173,6 +173,10 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
                             "phenix.refine uses Reduce to identify Asn, Gln, and "
                             "His residues that should be flipped, and then flips "
                             "them automatically.")
+        
+        form.addParam("doMolProbity", BooleanParam, label="Whether to run MolProbity",
+                      default=True, expertLevel=LEVEL_ADVANCED,
+                      help="Set to True to run MolProbity or False to skip this step.")
 
         # form.addParallelSection(threads=1, mpi=0)
 
@@ -180,9 +184,10 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
     def _insertAllSteps(self):
         self._insertFunctionStep('convertInputStep', self.REALSPACEFILE)
         self._insertFunctionStep('runRSrefineStep', self.REALSPACEFILE)
-        self._insertFunctionStep('runMolprobityStep', self.REALSPACEFILE)
-        if Plugin.getPhenixVersion() != PHENIXVERSION:
-            self._insertFunctionStep('runValidationCryoEMStep', self.REALSPACEFILE)
+        if self.doMolProbity.get():
+            self._insertFunctionStep('runMolprobityStep', self.REALSPACEFILE)
+            if Plugin.getPhenixVersion() != PHENIXVERSION:
+                self._insertFunctionStep('runValidationCryoEMStep', self.REALSPACEFILE)
         self._insertFunctionStep('createOutputStep')
 
     # --------------------------- STEPS functions --------------------------
@@ -253,7 +258,8 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
               sdterrLog = self.getLogsLastLines)
 
     def createOutputStep(self):
-        # self._getRSRefineOutput()
+        if not self.doMolProbity.get():
+            self._getRSRefineOutput()
         pdb = AtomStruct()
         pdb.setFileName(self.outAtomStructName)
 

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -347,6 +347,7 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
             fi.write("refinement.rigid_body {\n")
 
             for rigidBody in self.rigidBodySelections.get().split('\n'):
+                rigidBody = rigidBody.strip()
                 if not rigidBody.startswith('group'):
                     rigidBody = "group = {0}\n".format(rigidBody)
                 fi.write(rigidBody)

--- a/phenix/protocols/protocol_real_space_refine.py
+++ b/phenix/protocols/protocol_real_space_refine.py
@@ -342,7 +342,7 @@ class PhenixProtRunRSRefine(PhenixProtRunRefinementBase):
         args = args[:-1]
 
         if self.rigidBodySelections.get() != "":
-            RIGID_BODY_FILENAME = self._getExtraPath("rigid.eff")
+            RIGID_BODY_FILENAME = os.path.abspath(self._getExtraPath("rigid.eff"))
             fi = open(RIGID_BODY_FILENAME, 'w')
             fi.write("refinement.rigid_body {\n")
 

--- a/phenix/tests/test_protocol_real_space_refine.py
+++ b/phenix/tests/test_protocol_real_space_refine.py
@@ -394,7 +394,7 @@ class TestPhenixRSRefine(TestImportData):
                 'occupancy': False,
                 'nqh_flips': False,
                 'doMolProbity': False,
-                'rigidBodies': True
+                'rigidBody': True
                 }
         if Plugin.getPhenixVersion() == PHENIXVERSION:
             args['doSecondary'] = False
@@ -431,7 +431,7 @@ class TestPhenixRSRefine(TestImportData):
                 'occupancy': False,
                 'nqh_flips': False,
                 'doMolProbity': False,
-                'rigidBodies': True,
+                'rigidBody': True,
                 'rigidBodySelections': """chain A and resseq 122:160"""
                 }
         if Plugin.getPhenixVersion() == PHENIXVERSION:
@@ -469,7 +469,7 @@ class TestPhenixRSRefine(TestImportData):
                 'occupancy': False,
                 'nqh_flips': False,
                 'doMolProbity': False,
-                'rigidBodies': True,
+                'rigidBody': True,
                 'rigidBodySelections': """chain A and resseq 122:160
                                           chain A and resseq 30:74
                                           chain A and resseq 1:29 or chain A and resseq 75:121 or chain A and resseq 161:214"""

--- a/phenix/tests/test_protocol_real_space_refine.py
+++ b/phenix/tests/test_protocol_real_space_refine.py
@@ -432,7 +432,7 @@ class TestPhenixRSRefine(TestImportData):
                 'nqh_flips': False,
                 'doMolProbity': False,
                 'rigidBodies': True,
-                'rigidBodySelections': """"""
+                'rigidBodySelections': """chain A and resseq 122:160"""
                 }
         if Plugin.getPhenixVersion() == PHENIXVERSION:
             args['doSecondary'] = False
@@ -446,13 +446,13 @@ class TestPhenixRSRefine(TestImportData):
         with a volume provided directly as inputVol, the input PDB was fitted
         to the volume and refined previously by coot and refmac withouth mask
         in another project; (MolProbity has not been run as it is good to have
-        some tests without it); default refine strategy plus 2 defined rigid bodies
+        some tests without it); default refine strategy plus 3 defined rigid bodies
         """
         print ("Run phenix real_space_refine from imported volume and pdb file "
                "previously fitted and refined by Coot and Refmac without mask "
                "(copy of testPhenixRSRefineFromVolumeAndPDB1 except MolProbity "
                "has not been run as it is good to have some tests without it); "
-               "default refine strategy plus 2 defined rigid bodies")
+               "default refine strategy plus 3 defined rigid bodies")
 
         # Import Volume
         volume_refmac3 = self._importVolRefmac3()
@@ -470,7 +470,9 @@ class TestPhenixRSRefine(TestImportData):
                 'nqh_flips': False,
                 'doMolProbity': False,
                 'rigidBodies': True,
-                'rigidBodySelections': """"""
+                'rigidBodySelections': """chain A and resseq 122:160
+                                          chain A and resseq 30:74
+                                          chain A and resseq 1:29 or chain A and resseq 75:121 or chain A and resseq 161:214"""
                 }
         if Plugin.getPhenixVersion() == PHENIXVERSION:
             args['doSecondary'] = False

--- a/phenix/tests/test_protocol_real_space_refine.py
+++ b/phenix/tests/test_protocol_real_space_refine.py
@@ -329,7 +329,155 @@ class TestPhenixRSRefine(TestImportData):
                                       clashScore=4.47,
                                       overallScore=1.89,
                                       protRSRefine=protRSRefine)
+ 
+    def testPhenixRSRefineFromVolumeAndPDB2(self):
+        """ This test checks that phenix real_space_refine protocol runs
+        with a volume provided directly as inputVol, the input PDB was fitted
+        to the volume and refined previously by coot and refmac withouth mask
+        in another project; (MolProbity has not been run as it is good to have
+        some tests without it); default refine strategy
+        """
+        print ("Run phenix real_space_refine from imported volume and pdb file "
+               "previously fitted and refined by Coot and Refmac without mask "
+               "(copy of testPhenixRSRefineFromVolumeAndPDB1 except MolProbity "
+               "has not been run as it is good to have some tests without it); "
+               "default refine strategy")
 
+        # Import Volume
+        volume_refmac3 = self._importVolRefmac3()
+
+        # import PDB
+        structure_refmac3 = self._importStructRefmac3()
+
+        # real_space_refine
+        args = {'inputVolume': volume_refmac3,
+                'resolution': 3.5,
+                'inputStructure': structure_refmac3,
+                'numberOfThreads': 4,
+                # default parameters in Optimization strategy options
+                'occupancy': False,
+                'nqh_flips': False,
+                'doMolProbity': False
+                }
+        if Plugin.getPhenixVersion() == PHENIXVERSION:
+            args['doSecondary'] = False
+        protRSRefine = self.newProtocol(PhenixProtRunRSRefine, **args)
+        protRSRefine.setObjLabel('RSRefine\n refmac3.mrc and '
+                                   'refmac3.pdb\n')
+        self.launchProtocol(protRSRefine)
+
+    def testPhenixRSRefineFromVolumeAndPDB3a(self):
+        """ This test checks that phenix real_space_refine protocol runs
+        with a volume provided directly as inputVol, the input PDB was fitted
+        to the volume and refined previously by coot and refmac withouth mask
+        in another project; (MolProbity has not been run as it is good to have
+        some tests without it); default refine strategy plus default rigid bodies
+        """
+        print ("Run phenix real_space_refine from imported volume and pdb file "
+               "previously fitted and refined by Coot and Refmac without mask "
+               "(copy of testPhenixRSRefineFromVolumeAndPDB1 except MolProbity "
+               "has not been run as it is good to have some tests without it); "
+               "default refine strategy plus default rigid bodies")
+
+        # Import Volume
+        volume_refmac3 = self._importVolRefmac3()
+
+        # import PDB
+        structure_refmac3 = self._importStructRefmac3()
+
+        # real_space_refine
+        args = {'inputVolume': volume_refmac3,
+                'resolution': 3.5,
+                'inputStructure': structure_refmac3,
+                'numberOfThreads': 4,
+                # default parameters in Optimization strategy options
+                'occupancy': False,
+                'nqh_flips': False,
+                'doMolProbity': False,
+                'rigidBodies': True
+                }
+        if Plugin.getPhenixVersion() == PHENIXVERSION:
+            args['doSecondary'] = False
+        protRSRefine = self.newProtocol(PhenixProtRunRSRefine, **args)
+        protRSRefine.setObjLabel('RSRefine\n refmac3.mrc and '
+                                   'refmac3.pdb\n')
+        self.launchProtocol(protRSRefine)
+
+    def testPhenixRSRefineFromVolumeAndPDB3b(self):
+        """ This test checks that phenix real_space_refine protocol runs
+        with a volume provided directly as inputVol, the input PDB was fitted
+        to the volume and refined previously by coot and refmac withouth mask
+        in another project; (MolProbity has not been run as it is good to have
+        some tests without it); default refine strategy plus 1 defined rigid body
+        """
+        print ("Run phenix real_space_refine from imported volume and pdb file "
+               "previously fitted and refined by Coot and Refmac without mask "
+               "(copy of testPhenixRSRefineFromVolumeAndPDB1 except MolProbity "
+               "has not been run as it is good to have some tests without it); "
+               "default refine strategy plus 1 defined rigid body")
+
+        # Import Volume
+        volume_refmac3 = self._importVolRefmac3()
+
+        # import PDB
+        structure_refmac3 = self._importStructRefmac3()
+
+        # real_space_refine
+        args = {'inputVolume': volume_refmac3,
+                'resolution': 3.5,
+                'inputStructure': structure_refmac3,
+                'numberOfThreads': 4,
+                # default parameters in Optimization strategy options
+                'occupancy': False,
+                'nqh_flips': False,
+                'doMolProbity': False,
+                'rigidBodies': True,
+                'rigidBodySelections': """"""
+                }
+        if Plugin.getPhenixVersion() == PHENIXVERSION:
+            args['doSecondary'] = False
+        protRSRefine = self.newProtocol(PhenixProtRunRSRefine, **args)
+        protRSRefine.setObjLabel('RSRefine\n refmac3.mrc and '
+                                   'refmac3.pdb\n')
+        self.launchProtocol(protRSRefine)
+
+    def testPhenixRSRefineFromVolumeAndPDB3c(self):
+        """ This test checks that phenix real_space_refine protocol runs
+        with a volume provided directly as inputVol, the input PDB was fitted
+        to the volume and refined previously by coot and refmac withouth mask
+        in another project; (MolProbity has not been run as it is good to have
+        some tests without it); default refine strategy plus 2 defined rigid bodies
+        """
+        print ("Run phenix real_space_refine from imported volume and pdb file "
+               "previously fitted and refined by Coot and Refmac without mask "
+               "(copy of testPhenixRSRefineFromVolumeAndPDB1 except MolProbity "
+               "has not been run as it is good to have some tests without it); "
+               "default refine strategy plus 2 defined rigid bodies")
+
+        # Import Volume
+        volume_refmac3 = self._importVolRefmac3()
+
+        # import PDB
+        structure_refmac3 = self._importStructRefmac3()
+
+        # real_space_refine
+        args = {'inputVolume': volume_refmac3,
+                'resolution': 3.5,
+                'inputStructure': structure_refmac3,
+                'numberOfThreads': 4,
+                # default parameters in Optimization strategy options
+                'occupancy': False,
+                'nqh_flips': False,
+                'doMolProbity': False,
+                'rigidBodies': True,
+                'rigidBodySelections': """"""
+                }
+        if Plugin.getPhenixVersion() == PHENIXVERSION:
+            args['doSecondary'] = False
+        protRSRefine = self.newProtocol(PhenixProtRunRSRefine, **args)
+        protRSRefine.setObjLabel('RSRefine\n refmac3.mrc and '
+                                   'refmac3.pdb\n')
+        self.launchProtocol(protRSRefine)
     def testPhenixRSRefineFromVolumeAndPDB4(self):
         """ This test checks that phenix real_space_refine protocol runs
         with a volume provided directly as inputVol and the input PDB from


### PR DESCRIPTION
This pull request adds the option for rigid body definitions to the real space refinement protocol as another box on the form, which is used to create a file with the right format in point 8 at https://phenix-online.org/documentation/reference/real_space_refine.html#usage-examples. More information on atom selections can be found at https://phenix-online.org/documentation/reference/atom_selections.html#examples-for-selection-expressions.

This allows more sophisticated definitions of rigid bodies than the default one of using chains, for example, there could be a rigid body containing a group of residues from a particular chain that belong to a domain.